### PR TITLE
fix: use the plural form

### DIFF
--- a/src/spec/crypto-conditions.md
+++ b/src/spec/crypto-conditions.md
@@ -130,7 +130,7 @@ Since evaluation of some of the logic gates in the circuit (those that are signa
 
 # Introduction
 
-Crypto-conditions is a scheme for composing signature-like structures from one or more existing signature scheme or hash digest primitives. It defines a mechanism for these existing primitives to be combined and grouped to create complex signature arrangements but still maintain the useful properties of a simple signature, most notably, that a deterministic algorithm exists to verify the signature against a message given a public key.
+Crypto-conditions is a scheme for composing signature-like structures from one or more existing signature schemes or hash digest primitives. It defines a mechanism for these existing primitives to be combined and grouped to create complex signature arrangements but still maintain the useful properties of a simple signature, most notably, that a deterministic algorithm exists to verify the signature against a message given a public key.
 
 Using crypto-conditions, existing primitives such as RSA and ED25519 signature schemes and SHA256 digest algorithms can be used as logic gates to construct complex boolean circuits which can then be used as a compound signature. The validation function for these compound signatures takes as input the fingerprint of the circuit, called the condition, the circuit definition and minimum required logic gates with their inputs, called the fulfillment, and a message.
 


### PR DESCRIPTION
NOTE: I am not an English native speaker, so I could be wrong. I am basing the change on two comments found on English Language & Usage Stack Exchange:

> Since you would say "There are one or more apples," -- [Peter Shor](https://english.stackexchange.com/questions/40669/there-is-are-one-or-several-apple-s#comment74583_40669)

and

> It says in Warriner's English Grammar and Composition, Complete Course, Page 92, "when a singular and a plural subject are joined by or, the verb agrees with the nearer subject"; thus, you would say, "One (singular) or more (plural) books are on the shelf." -- [Jeanne](https://english.stackexchange.com/questions/13284/which-is-correct-one-or-more-is-or-one-or-more-are#comment612315_13284)